### PR TITLE
Upgrade from .NET Core 3.1 to .NET 5.0

### DIFF
--- a/src/Yale.Portal/Dockerfile
+++ b/src/Yale.Portal/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
 WORKDIR /src
 COPY ["Yale.Portal/Yale.Portal.csproj", "Yale.Portal/"]
 RUN dotnet restore "Yale.Portal/Yale.Portal.csproj"

--- a/src/Yale.Portal/Yale.Portal.csproj
+++ b/src/Yale.Portal/Yale.Portal.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>6f5a7991-2780-4d14-a015-616b2d3912f8</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
     <PackageReference Include="Yale" Version="1.0.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Update `TargetFramework` from `netcoreapp3.1` to `net5.0` in `Yale.Portal.csproj`
- Update Docker base images from `mcr.microsoft.com/dotnet/core/*` to `mcr.microsoft.com/dotnet/*` (path changed in .NET 5)
- Bump NuGet package versions to their 5.0.x equivalents (`Microsoft.Extensions.Logging.Debug`, `Microsoft.VisualStudio.Web.CodeGeneration.Design`, `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation`)

## Test plan

- [ ] Run `dotnet restore` and verify no package resolution errors
- [ ] Run `dotnet build` and verify the project compiles successfully
- [ ] Run `docker build` and verify the image builds correctly
- [ ] Smoke-test the application to confirm it starts and serves requests

https://claude.ai/code/session_01QhrfdAhjDo9i4YGwSCemUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhrfdAhjDo9i4YGwSCemUb)_