### PR TITLE
Upgrade to .NET 10 and update NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '10.0.x'
       - run: dotnet build src/Yale.Portal/Yale.Portal.csproj --configuration Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Yale-Portal is a Blazor Server application that provides a web interface for the [Yale expression evaluation library](https://github.com/Verent/Yale). It allows users to evaluate mathematical and logical expressions at runtime by parsing and compiling inputs to CIL on the server. Live at: https://yale.verent.com/
+
+## Build & Run Commands
+
+```bash
+# Build
+dotnet build src/Yale.Portal/Yale.Portal.csproj
+
+# Run (development)
+dotnet run --project src/Yale.Portal/Yale.Portal.csproj
+
+# Build for release
+dotnet build src/Yale.Portal/Yale.Portal.csproj --configuration Release
+```
+
+There are no tests or linting steps in this project. The CI pipeline (`.github/workflows/build.yml`) only runs a Release build on pull requests.
+
+## Architecture
+
+**Stack:** .NET 5.0, Blazor Server (SignalR/WebSockets), Razor components, Bootstrap.
+
+No Node.js, no REST API, no database. All state is held in scoped server-side services; client-server communication uses SignalR (Blazor's default for server-side hosting).
+
+### Core Service: `YaleService`
+
+`src/Yale.Portal/Services/YaleService.cs` — the single service that wraps the Yale library. It extends `ComputeInstance` and is registered as a **scoped** service (one instance per SignalR connection/session).
+
+Key constraints enforced by the service:
+- `MaxExpressions = 5`
+- `MaxVariables = 5`
+- `Math` type imported, so expressions like `Sin(x)` work out of the box
+
+**AddValue** — parses `"key=value"` strings with type inference: tries int → double → bool → falls back to string.
+
+**AddExpression** — parses `"key:expression"` strings (colon-separated). Silently swallows exceptions on invalid input; returns a bool indicating success.
+
+**TryEvaluate** — safely evaluates a named expression and returns the result.
+
+### Pages & Routing
+
+Routes are declared via `@page` directives on Razor components:
+
+| Route | Component | Purpose |
+|-------|-----------|---------|
+| `/` | `Pages/Index.razor` | Landing page |
+| `/terminal` | `Pages/Terminal.razor` | Interactive REPL |
+| `/about` | `Pages/About.razor` | Credits |
+| `/updates` | `Pages/Updates.razor` | Release notes |
+
+`Pages/_Host.cshtml` is the HTML shell (non-Blazor entry point). `App.razor` is the root Blazor router. `Shared/MainLayout.razor` wraps all pages with the sidebar layout.
+
+### Terminal.razor — the main interactive component
+
+The most complex component. It provides a REPL-style interface driven entirely by Blazor event bindings (`@onkeyup`, `@bind`). Input is parsed client-side with three regex patterns before being routed to `YaleService`:
+
+- **Variable assignment** (`x=4`, `x=3.14`, `x=hello`) — matches `^[a-zA-Z]+[=][\w\s.]+$`
+- **Expression definition** (`e:2*x`) — matches `[a-zA-Z]+[:].+$`
+- **Evaluation** (`e`) — matches `^[a-zA-Z]+$`
+
+The component maintains a command history and supports arrow-key navigation through it.
+
+## Key Conventions
+
+- **Service injection** in Razor components: `@inject YaleService service`
+- **Culture** is hardcoded to `en-US` in `Startup.cs` — relevant for decimal parsing
+- **Error handling** in `YaleService` is silent (swallows exceptions and returns bool). When extending the service, follow the same pattern of returning success indicators rather than propagating exceptions to the UI.
+- **Static assets** live in `wwwroot/` — Bootstrap and Open Iconic are vendored there (no npm).

--- a/src/Yale.Portal/Dockerfile
+++ b/src/Yale.Portal/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["Yale.Portal/Yale.Portal.csproj", "Yale.Portal/"]
 RUN dotnet restore "Yale.Portal/Yale.Portal.csproj"

--- a/src/Yale.Portal/Yale.Portal.csproj
+++ b/src/Yale.Portal/Yale.Portal.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>6f5a7991-2780-4d14-a015-616b2d3912f8</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="Yale" Version="1.0.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Upgrades target framework from `net5.0` (EOL) to `net10.0` (LTS)
- Updates all Microsoft NuGet packages to their latest stable versions matching .NET 10
- Updates Dockerfile base images from `5.0-buster-slim` to `10.0`
- Updates CI workflow to use `dotnet-version: '10.0.x'`
- `Yale` remains at `1.0.0.1` — this is already the latest stable release (a prerelease 2.0.0 exists but was not included)

## Package changes

| Package | Before | After |
|---------|--------|-------|
| `Microsoft.Extensions.Logging.Debug` | 5.0.0 | 10.0.7 |
| `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` | 5.0.0 | 10.0.7 |
| `Microsoft.VisualStudio.Web.CodeGeneration.Design` | 5.0.2 | 10.0.2 |
| `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` | 1.10.8 | 1.23.0 |
| `Yale` | 1.0.0.1 | 1.0.0.1 (no change) |

## Test plan

- [ ] CI build passes with .NET 10
- [ ] App starts and the `/terminal` REPL works as expected

https://claude.ai/code/session_011PBBdhg88SifUU6pBunmf5

---
_Generated by [Claude Code](https://claude.ai/code/session_011PBBdhg88SifUU6pBunmf5)_